### PR TITLE
Adds functionality to scan for network SSIDs during configuration.

### DIFF
--- a/badger2040w/main.py
+++ b/badger2040w/main.py
@@ -67,8 +67,8 @@ def setup_mode():
     found_wifi_networks = {}
     
     for n in networks:
-        print(n[0])
-        ssid = n[0].decode()
+        ssid = n[0].decode().strip('\x00')
+        # TODO remove this when satisfied.
         print(f"network '{ssid}'")
         if len(ssid) > 0:
             rssi = n[3]

--- a/badger2040w/main.py
+++ b/badger2040w/main.py
@@ -67,9 +67,10 @@ def setup_mode():
     found_wifi_networks = {}
     
     for n in networks:
+        print(n[0])
         ssid = n[0].decode()
+        print(f"network '{ssid}'")
         if len(ssid) > 0:
-            ssid = n[0].decode()
             rssi = n[3]
             if ssid in found_wifi_networks:
                 if found_wifi_networks[ssid] < rssi:

--- a/badger2040w/main.py
+++ b/badger2040w/main.py
@@ -60,11 +60,30 @@ def setup_mode():
     display_centered("Connect to WiFi network", 35, 2)
     display_centered(config.AP_NAME, 70, 3)
     
+    wlan = network.WLAN(network.STA_IF)
+    wlan.active(True)
+    networks = wlan.scan()
+    
+    found_wifi_networks = {}
+    
+    for n in networks:
+        ssid = n[0].decode()
+        if len(ssid) > 0:
+            ssid = n[0].decode()
+            rssi = n[3]
+            if ssid in found_wifi_networks:
+                if found_wifi_networks[ssid] < rssi:
+                    found_wifi_networks[ssid] = rssi
+            else:
+                found_wifi_networks[ssid] = rssi
+
+    wifi_networks_by_strength = sorted(found_wifi_networks.items(), key = lambda x:x[1], reverse = True)
+
     def ap_index(request):
         if request.headers.get("host").lower() != config.AP_DOMAIN.lower():
             return render_template(f"{TEMPLATE_PATH}/redirect.html", domain = config.AP_DOMAIN.lower())
-
-        return render_template(f"{TEMPLATE_PATH}/index.html", lat = str(config.DEFAULT_LATITUDE), lng = str(config.DEFAULT_LONGITUDE), loc = config.DEFAULT_PLACE)
+                
+        return render_template(f"{TEMPLATE_PATH}/index.html", lat = str(config.DEFAULT_LATITUDE), lng = str(config.DEFAULT_LONGITUDE), loc = config.DEFAULT_PLACE, wifis = wifi_networks_by_strength)
 
     def ap_configure(request):
         print("Saving wifi credentials...")

--- a/badger2040w/templates/index.html
+++ b/badger2040w/templates/index.html
@@ -15,7 +15,10 @@
                     <p>You&apos;ll need your network name or SSID and password.</p>
                     <p><b>These are case sensitive, so be sure to enter them correctly.</b></p>
                     <label for="ssid">SSID:</label>
-                    <input type="text" id="ssid" name="ssid" placeholder="WiFi SSID" required>
+                    <select name="ssid" id="ssid">
+                        {{"" if len(wifis) == 0 else "".join(["""<option value="{0}">{0}</option>""".format(w[0]) for w in wifis])}}                        
+                        <option value="other">Other...</option>
+                    </select>
                     <span class="pure-form-message">This is a required field.</span>
                     <label for="password">Password:</label>
                     <input type="text" id="password" name="password" placeholder="WiFi Password" required>

--- a/badger2040w/templates/index.html
+++ b/badger2040w/templates/index.html
@@ -15,11 +15,11 @@
                     <p>You&apos;ll need your network name or SSID and password.</p>
                     <p><b>These are case sensitive, so be sure to enter them correctly.</b></p>
                     <label for="ssid">SSID:</label>
-                    <select name="ssid" id="ssid" onchange="ssidChanged()">
+                    <select id="ssidselect" onchange="ssidChanged()">
                         {{"" if len(wifis) == 0 else "".join(["""<option value="{0}">{0}</option>""".format(w[0]) for w in wifis])}}                        
                         <option value="other">Other...</option>
                     </select>
-                    <input type="text" id="otherssid" name="otherssid" placeholder="WiFi SSID" hidden>
+                    <input type="text" id="ssid" name="ssid" placeholder="WiFi SSID" value="{{"" if len(wifis) == 0 else wifis[0][0]}}" hidden required>
                     <span class="pure-form-message">This is a required field.</span>
                     <label for="password">Password:</label>
                     <input type="text" id="password" name="password" placeholder="WiFi Password" required>
@@ -42,13 +42,14 @@
         </div>
         <script>
             function ssidChanged() {
-                const selectedSSID = document.getElementById('ssid').value;
-                const otherSSIDElem = document.getElementById('otherssid');
+                const selectedSSID = document.getElementById('ssidselect').value;
+                const ssidElem = document.getElementById('ssid');
                 if (selectedSSID === 'other') {
-                    otherSSIDElem.hidden = false;
+                    ssidElem.value = '';
+                    ssidElem.hidden = false;
                 } else {
-                    otherSSIDElem.hidden = true;
-                    otherSSIDElem.value = '';
+                    ssidElem.hidden = true;                    
+                    ssidElem.value = selectedSSID;
                 }
             }
                         

--- a/badger2040w/templates/index.html
+++ b/badger2040w/templates/index.html
@@ -15,10 +15,11 @@
                     <p>You&apos;ll need your network name or SSID and password.</p>
                     <p><b>These are case sensitive, so be sure to enter them correctly.</b></p>
                     <label for="ssid">SSID:</label>
-                    <select name="ssid" id="ssid">
+                    <select name="ssid" id="ssid" onchange="ssidChanged()">
                         {{"" if len(wifis) == 0 else "".join(["""<option value="{0}">{0}</option>""".format(w[0]) for w in wifis])}}                        
                         <option value="other">Other...</option>
                     </select>
+                    <input type="text" id="otherssid" name="otherssid" placeholder="WiFi SSID" hidden>
                     <span class="pure-form-message">This is a required field.</span>
                     <label for="password">Password:</label>
                     <input type="text" id="password" name="password" placeholder="WiFi Password" required>
@@ -40,6 +41,17 @@
             </form>
         </div>
         <script>
+            function ssidChanged() {
+                const selectedSSID = document.getElementById('ssid').value;
+                const otherSSIDElem = document.getElementById('otherssid');
+                if (selectedSSID === 'other') {
+                    otherSSIDElem.hidden = false;
+                } else {
+                    otherSSIDElem.hidden = true;
+                    otherSSIDElem.value = '';
+                }
+            }
+                        
             function validateForm(form) {
                 // The ssid field must contain something.
                 if (form.ssid.value.trim() === '') {


### PR DESCRIPTION
Allows the user to select from SSIDs that the device can see rather than having to type in their network name accurately.

Tests:

- [x] Allow for case where they still want to manually enter an SSID e.g. because their network doesn't broadcast one.
- [x] Test fully.
- [x] Test with an Android phone.

Closes #1 